### PR TITLE
Simplify and fix version check

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -46,18 +46,16 @@ checkpythonenvironment() {
        exit 1
     fi
 
-    FULLVER=$(python -c 'import sys; print(sys.version)')
-    VERSION=$(echo $FULLVER | sed 's/\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\).*/\1\2\3/g')
-    if [ $VERSION -lt 26 ]; then
+    PYTHON_VERSION=$(python -c 'import sys; print("%s%s" % (sys.version_info[0], sys.version_info[1]))')
+    if [ $PYTHON_VERSION -lt 26 ]; then
        echo "Hitch will not work with python versions 3.0.x, 3.1.x, 3.2.x or versions lower than 2.6."
        echo "You probably need to upgrade your system to something more recent, or use a more up to date distro to continue."
        help
        exit 1
     fi
 
-    FULLVER=$(python3 -c 'import sys; print(sys.version)')
-    VERSION=$(echo $FULLVER | sed 's/\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\).*/\1\2\3/g')
-    if [ $VERSION -gt 30 ] && [ $VERSION -lt 33 ]; then
+    PYTHON3_VERSION=$(python3 -c 'import sys; print("{}{}".format(sys.version_info[0], sys.version_info[1]))')
+    if [ $PYTHON3_VERSION -gt 30 ] && [ $PYTHON3_VERSION -lt 33 ]; then
        echo "Hitch will not work with python 3 versions below 3.3"
        echo "You probably need to upgrade your system to something more recent, or use a more up to date distro to continue."
        help


### PR DESCRIPTION
When the version of python installed contains a letter, i.e. Python 3.5.0a1, it produces the following output.

```
$ ./init.sh
Installing and initializing hitch...
Package 'python' is installed
Package 'python3' is installed
Requirement already up-to-date: pip in /usr/local/lib/python2.7/site-packages
Requirement already up-to-date: setuptools in /usr/local/lib/python2.7/site-packages
Requirement already up-to-date: virtualenv in /usr/local/lib/python2.7/site-packages
Requirement already up-to-date: hitch in /usr/local/lib/python2.7/site-packages
./init.sh: line 51: [: too many arguments
./init.sh: line 60: [: too many arguments
```

This PR is to modify the version check to only extract the major and minor version numbers.
